### PR TITLE
Add dockerfile for building unit images

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+
+    <section class="row hero-row no-border">
+        <div class="wrapper">
+            <div class="eight-col">
+                <h1>Page not found</h1>
+                <p class="intro">There's nothing here. Why not <a href="/">visit the homepage</a>?</p>
+            </div>
+        </div>
+    </section>
+
+    {% include contextual-footer.html %}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install --yes nginx
+
+WORKDIR /srv
+ADD _site .
+ADD nginx.conf /etc/nginx/sites-enabled/default
+
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    root /srv;
+
+    index index.html;
+
+    # Log to stdout
+    access_log /dev/stdout;
+    error_log /dev/stderr info;
+
+    # Show 404 page
+    error_page 404 /404.html;
+
+    server_name _;
+
+    # Remove index or index.html from URIs
+    if ($request_uri ~ ^.*/index(.html)?$) {
+        rewrite ^(.*/)index(.html)? $1 permanent;
+    }
+
+    # Remove slashes form URIs if it's not a directory
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
+
+    # Add slashes from URIs if it's a directory
+    if (-d $request_filename) {
+        rewrite ^/(.*[^/])$ /$1/ permanent;
+    }
+
+    # For finding files from URIs
+    # First try the URI directly, then try adding .html, then try treating it as a directory
+    # Finally fall back to 404
+    location ~ ^/.+$ {
+        try_files $uri $uri.html $uri/ =404;
+    }
+}
+


### PR DESCRIPTION
These images will be used in K8s. They copy the static site files into the image and then host it on port 80 with the nginx config filel also included in this branch.

I've also added a basic 404 page, as it didn't have one before.

QA
--

``` bash
./run build
docker build -t snapcraft.io-static-pages .
docker run -ti -p 80:80 snapcraft.io-static-pages
```

Now visit <http://127.0.0.1/>, <http://127.0.0.1/docs>, <http://127.0.0.1/docs/core>, <http://127.0.0.1/docs/core/install/>, <http://127.0.0.1/nonexistentpage>. Check you see what you expect.